### PR TITLE
Fixing Verify order crash

### DIFF
--- a/include/fakeit/DefaultEventFormatter.hpp
+++ b/include/fakeit/DefaultEventFormatter.hpp
@@ -116,7 +116,8 @@ namespace fakeit {
             for (unsigned int i = 0; i < max_size; i++) {
                 out << "  ";
                 auto invocation = actualSequence[i];
-                out << invocation->format();
+                // Sometimes the object is not successfully dynamic casted which means format() would crash. So we just print the method name instead.
+                out << invocation->getMethod().name();
                 if (i < max_size - 1)
                     out << std::endl;
             }


### PR DESCRIPTION
When running the `ActiveDirectoryIdentityTests` in minecraftpe I was running into an issue when using `fakeit::Verify`. In that class we use `fakeit::Verify(Method(func1) + Method(func2) + Method(func3))` to check that the calls happen in the right order. When they were in the wrong order, there was an error that was causing a crash when fakeit was trying to print out the error info. 

This PR fixes this print so that it will give slightly less info but will not crash. It still prints out the names of the methods in the order they happened so the info is still very helpful to determining the order of calls.

There's a sizeable discussion thread here: https://mojangab.slack.com/archives/C6TCM5S3A/p1613789934000400