### PR TITLE
Borrowing a fix from another fork of FakeIt to fix colliding mocking ids

### DIFF
--- a/build/sources.mk
+++ b/build/sources.mk
@@ -14,6 +14,8 @@ CPP_SRCS += \
 	move_only_return_tests.cpp \
 	msc_stubbing_multiple_values_tests.cpp \
 	msc_type_info_tests.cpp \
+	multiple_translation_units_stub.cpp \
+	multiple_translation_units_stub_test.cpp \
 	overloadded_methods_tests.cpp \
 	referece_types_tests.cpp \
 	remove_const_volatile_tests.cpp \

--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -57,55 +57,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -89,7 +89,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -212,7 +212,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -314,7 +314,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {

--- a/include/fakeit/api_macros.hpp
+++ b/include/fakeit/api_macros.hpp
@@ -1,8 +1,18 @@
 #pragma once
 
+#include "mockutils/constexpr_hash.hpp"
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -17,13 +27,13 @@
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -27,9 +27,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -43,15 +43,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -100,7 +100,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -189,7 +189,7 @@ namespace fakeit {
         //
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {

--- a/include/mockutils/MethodProxy.hpp
+++ b/include/mockutils/MethodProxy.hpp
@@ -6,7 +6,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -16,7 +16,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -25,7 +25,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };

--- a/include/mockutils/MethodProxyCreator.hpp
+++ b/include/mockutils/MethodProxyCreator.hpp
@@ -11,7 +11,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -29,14 +29,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -45,7 +45,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }

--- a/include/mockutils/VTUtils.hpp
+++ b/include/mockutils/VTUtils.hpp
@@ -63,7 +63,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }

--- a/include/mockutils/constexpr_hash.hpp
+++ b/include/mockutils/constexpr_hash.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) { 
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+    
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}

--- a/include/mockutils/mscpp/VirtualTable.hpp
+++ b/include/mockutils/mscpp/VirtualTable.hpp
@@ -189,7 +189,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -235,7 +235,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -262,7 +262,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1; // use the last cookie
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.278366
+ *  Generated: 2023-03-09 16:30:08.010273
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5333,7 +5333,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5525,7 +5525,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5571,7 +5571,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5598,7 +5598,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5873,7 +5873,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5883,7 +5883,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5892,7 +5892,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5905,7 +5905,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5923,14 +5923,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5939,7 +5939,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5950,9 +5950,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -5966,15 +5966,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -6023,7 +6023,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6112,7 +6112,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8576,7 +8576,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8699,7 +8699,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8801,7 +8801,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8925,55 +8925,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -10001,9 +10001,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -10018,13 +10043,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.334907
+ *  Generated: 2023-03-09 16:30:08.078124
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5371,7 +5371,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5563,7 +5563,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5609,7 +5609,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5636,7 +5636,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5911,7 +5911,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5921,7 +5921,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5930,7 +5930,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5943,7 +5943,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5961,14 +5961,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5977,7 +5977,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5988,9 +5988,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -6004,15 +6004,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -6061,7 +6061,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6150,7 +6150,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8614,7 +8614,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8737,7 +8737,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8839,7 +8839,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8963,55 +8963,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -10025,9 +10025,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -10042,13 +10067,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/cute/fakeit.hpp
+++ b/single_header/cute/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.391446
+ *  Generated: 2023-03-09 16:30:08.141418
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5298,7 +5298,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5490,7 +5490,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5536,7 +5536,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5563,7 +5563,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5838,7 +5838,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5848,7 +5848,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5857,7 +5857,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5870,7 +5870,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5888,14 +5888,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5904,7 +5904,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5915,9 +5915,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -5931,15 +5931,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -5988,7 +5988,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6077,7 +6077,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8541,7 +8541,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8664,7 +8664,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8766,7 +8766,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8890,55 +8890,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -9966,9 +9966,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -9983,13 +10008,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/doctest/fakeit.hpp
+++ b/single_header/doctest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.448465
+ *  Generated: 2023-03-09 16:30:08.204730
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5326,7 +5326,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5518,7 +5518,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5564,7 +5564,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5591,7 +5591,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5866,7 +5866,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5876,7 +5876,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5885,7 +5885,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5898,7 +5898,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5916,14 +5916,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5932,7 +5932,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5943,9 +5943,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -5959,15 +5959,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -6016,7 +6016,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6105,7 +6105,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8569,7 +8569,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8692,7 +8692,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8794,7 +8794,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8918,55 +8918,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -9980,9 +9980,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -9997,13 +10022,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.505022
+ *  Generated: 2023-03-09 16:30:08.268034
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5298,7 +5298,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5490,7 +5490,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5536,7 +5536,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5563,7 +5563,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5838,7 +5838,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5848,7 +5848,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5857,7 +5857,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5870,7 +5870,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5888,14 +5888,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5904,7 +5904,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5915,9 +5915,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -5931,15 +5931,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -5988,7 +5988,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6077,7 +6077,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8541,7 +8541,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8664,7 +8664,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8766,7 +8766,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8890,55 +8890,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -9966,9 +9966,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -9983,13 +10008,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.561022
+ *  Generated: 2023-03-09 16:30:08.331328
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5320,7 +5320,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5512,7 +5512,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5558,7 +5558,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5585,7 +5585,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5860,7 +5860,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5870,7 +5870,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5879,7 +5879,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5892,7 +5892,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5910,14 +5910,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5926,7 +5926,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5937,9 +5937,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -5953,15 +5953,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -6010,7 +6010,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6099,7 +6099,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8563,7 +8563,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8686,7 +8686,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8788,7 +8788,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8912,55 +8912,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -9974,9 +9974,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -9991,13 +10016,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.613583
+ *  Generated: 2023-03-09 16:30:08.395009
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5322,7 +5322,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5514,7 +5514,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5560,7 +5560,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5587,7 +5587,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5862,7 +5862,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5872,7 +5872,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5881,7 +5881,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5894,7 +5894,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5912,14 +5912,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5928,7 +5928,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5939,9 +5939,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -5955,15 +5955,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -6012,7 +6012,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6101,7 +6101,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8565,7 +8565,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8688,7 +8688,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8790,7 +8790,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8914,55 +8914,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -9990,9 +9990,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -10007,13 +10032,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.667580
+ *  Generated: 2023-03-09 16:30:08.458304
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5305,7 +5305,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5497,7 +5497,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5543,7 +5543,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5570,7 +5570,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5845,7 +5845,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5855,7 +5855,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5864,7 +5864,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5877,7 +5877,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5895,14 +5895,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5911,7 +5911,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5922,9 +5922,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -5938,15 +5938,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -5995,7 +5995,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6084,7 +6084,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8548,7 +8548,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8671,7 +8671,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8773,7 +8773,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8897,55 +8897,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -9973,9 +9973,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -9990,13 +10015,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.720146
+ *  Generated: 2023-03-09 16:30:08.521985
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5306,7 +5306,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5498,7 +5498,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5544,7 +5544,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5571,7 +5571,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5846,7 +5846,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5856,7 +5856,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5865,7 +5865,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5878,7 +5878,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5896,14 +5896,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5912,7 +5912,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5923,9 +5923,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -5939,15 +5939,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -5996,7 +5996,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6085,7 +6085,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8549,7 +8549,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8672,7 +8672,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8774,7 +8774,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8898,55 +8898,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -9974,9 +9974,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -9991,13 +10016,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.774146
+ *  Generated: 2023-03-09 16:30:08.585664
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5374,7 +5374,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5566,7 +5566,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5612,7 +5612,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5639,7 +5639,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5914,7 +5914,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5924,7 +5924,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5933,7 +5933,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5946,7 +5946,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5964,14 +5964,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5980,7 +5980,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5991,9 +5991,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -6007,15 +6007,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -6064,7 +6064,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6153,7 +6153,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8617,7 +8617,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8740,7 +8740,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8842,7 +8842,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8966,55 +8966,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -10028,9 +10028,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -10045,13 +10070,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-02-24 15:54:13.831706
+ *  Generated: 2023-03-09 16:30:08.635451
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5345,7 +5345,7 @@ namespace fakeit {
 		}
 
         template<typename C>
-        static unsigned int getVTSize() {
+        static size_t getVTSize() {
             struct Derrived : public C {
                 virtual void endOfVt() {
                 }
@@ -5537,7 +5537,7 @@ namespace fakeit {
         }
 
         void copyFrom(VirtualTable<C, baseclasses...> &from) {
-            unsigned int size = VTUtils::getVTSize<C>();
+            auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
@@ -5583,7 +5583,7 @@ namespace fakeit {
             setCookie(dtorCookieIndex, method);
         }
 
-        unsigned int getSize() {
+        size_t getSize() {
             return VTUtils::getVTSize<C>();
         }
 
@@ -5610,7 +5610,7 @@ namespace fakeit {
         static const unsigned int dtorCookieIndex = numOfCookies - 1;
 
         static void **buildVTArray() {
-            int vtSize = VTUtils::getVTSize<C>();
+            auto vtSize = VTUtils::getVTSize<C>();
             auto array = new void *[vtSize + numOfCookies + 1]{};
             RTTICompleteObjectLocator<C, baseclasses...> *objectLocator = new RTTICompleteObjectLocator<C, baseclasses...>(
                     typeid(C));
@@ -5885,7 +5885,7 @@ namespace fakeit {
 
     struct MethodProxy {
 
-        MethodProxy(unsigned int id, unsigned int offset, void *vMethod) :
+        MethodProxy(size_t id, unsigned int offset, void *vMethod) :
                 _id(id),
                 _offset(offset),
                 _vMethod(vMethod) {
@@ -5895,7 +5895,7 @@ namespace fakeit {
             return _offset;
         }
 
-        unsigned int getId() const {
+        size_t getId() const {
             return _id;
         }
 
@@ -5904,7 +5904,7 @@ namespace fakeit {
         }
 
     private:
-        unsigned int _id;
+        size_t _id;
         unsigned int _offset;
         void *_vMethod;
     };
@@ -5917,7 +5917,7 @@ namespace fakeit {
     struct InvocationHandlerCollection {
         static const unsigned int VtCookieIndex = 0;
 
-        virtual Destructible *getInvocatoinHandlerPtrById(unsigned int index) = 0;
+        virtual Destructible *getInvocatoinHandlerPtrById(size_t index) = 0;
 
         static InvocationHandlerCollection *getInvocationHandlerCollection(void *instance) {
             VirtualTableBase &vt = VirtualTableBase::getVTable(instance);
@@ -5935,14 +5935,14 @@ namespace fakeit {
 
     public:
 
-        template<unsigned int id>
+        template<size_t id>
         MethodProxy createMethodProxy(unsigned int offset) {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
     protected:
 
-        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+        R methodProxy(size_t id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
@@ -5951,7 +5951,7 @@ namespace fakeit {
             return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
-        template<int id>
+        template<size_t id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
@@ -5962,9 +5962,9 @@ namespace fakeit {
 
     class InvocationHandlers : public InvocationHandlerCollection {
         std::vector<std::shared_ptr<Destructible>> &_methodMocks;
-        std::vector<unsigned int> &_offsets;
+        std::vector<size_t> &_offsets;
 
-        unsigned int getOffset(unsigned int id) const
+        unsigned int getOffset(size_t id) const
         {
             unsigned int offset = 0;
             for (; offset < _offsets.size(); offset++) {
@@ -5978,15 +5978,15 @@ namespace fakeit {
     public:
         InvocationHandlers(
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
-                std::vector<unsigned int> &offsets) :
+                std::vector<size_t> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
-			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			for (auto it = _offsets.begin(); it != _offsets.end(); ++it)
 			{
 				*it = std::numeric_limits<int>::max();
 			}
         }
 
-        Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {
+        Destructible *getInvocatoinHandlerPtrById(size_t id) override {
             unsigned int offset = getOffset(id);
             std::shared_ptr<Destructible> ptr = _methodMocks[offset];
             return ptr.get();
@@ -6035,7 +6035,7 @@ namespace fakeit {
         {
         }
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         void stubMethod(R(C::*vMethod)(arglist...), MethodInvocationHandler<R, arglist...> *methodInvocationHandler) {
             auto offset = VTUtils::getOffset(vMethod);
             MethodProxyCreator<R, arglist...> creator;
@@ -6124,7 +6124,7 @@ namespace fakeit {
 
         std::vector<std::shared_ptr<Destructible>> _methodMocks;
         std::vector<std::shared_ptr<Destructible>> _members;
-        std::vector<unsigned int> _offsets;
+        std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
 
         FakeObject<C, baseclasses...> &getFake() {
@@ -8588,7 +8588,7 @@ namespace fakeit {
             return DataMemberStubbingRoot<T, DataType>();
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stubMethod(R(T::*vMethod)(arglist...)) {
             return MockingContext<R, arglist...>(new UniqueMethodMockingContextImpl < id, R, arglist... >
                    (*this, vMethod));
@@ -8711,7 +8711,7 @@ namespace fakeit {
         };
 
 
-        template<int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
@@ -8813,7 +8813,7 @@ namespace fakeit {
             return origMethodPtr;
         }
 
-        template<unsigned int id, typename R, typename ... arglist>
+        template<size_t id, typename R, typename ... arglist>
         RecordedMethodBody<R, arglist...> &stubMethodIfNotStubbed(DynamicProxy<C, baseclasses...> &proxy,
                                                                   R (C::*vMethod)(arglist...)) {
             if (!proxy.isMethodStubbed(vMethod)) {
@@ -8937,55 +8937,55 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+        template<size_t id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
             auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
@@ -9999,9 +9999,34 @@ namespace fakeit {
     };
 
 }
+
+namespace fakeit {
+
+    constexpr size_t _FNV_prime = sizeof(size_t) == 4 ? 16777619ULL : 1099511628211ULL;
+    constexpr size_t _FNV_offset_basis = sizeof(size_t) == 4 ? 2166136261ULL : 14695981039346656037ULL;
+
+    constexpr size_t _constExprHashImpl(const char* str, size_t count) {
+        return count ? (_constExprHashImpl(str, count - 1) ^ str[count - 1]) * _FNV_prime : _FNV_offset_basis;
+    }
+
+    template<size_t N>
+    constexpr size_t constExprHash(const char(&str)[N]) {
+        return _constExprHashImpl(str, N);
+    }
+
+}
+
 #ifdef _MSC_VER
 #define __func__ __FUNCTION__
 #endif
+
+#define COUNTER_STRINGIFY( counter ) #counter
+
+#define STUB_ID_STR( counter ) \
+    __FILE__ COUNTER_STRINGIFY(counter)
+
+#define STUB_ID(counter) \
+    fakeit::constExprHash(STUB_ID_STR(counter))
 
 #define MOCK_TYPE(mock) \
     std::remove_reference<decltype((mock).get())>::type
@@ -10016,13 +10041,13 @@ namespace fakeit {
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<STUB_ID(__COUNTER__)>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/tests/FakeIt.vcxproj
+++ b/tests/FakeIt.vcxproj
@@ -78,6 +78,7 @@
     <ClInclude Include="..\include\mockutils\TupleDispatcher.hpp" />
     <ClInclude Include="..\include\mockutils\TuplePrinter.hpp" />
     <ClInclude Include="..\include\mockutils\type_utils.hpp" />
+    <ClInclude Include="..\include\mockutils\constexpr_hash.hpp" />
     <ClInclude Include="..\include\mockutils\union_cast.hpp" />
     <ClInclude Include="..\include\mockutils\VirtualOffestSelector.hpp" />
     <ClInclude Include="..\include\mockutils\VirtualTable.hpp" />

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -142,6 +142,8 @@
     <ClCompile Include="move_only_return_tests.cpp" />
     <ClCompile Include="msc_stubbing_multiple_values_tests.cpp" />
     <ClCompile Include="msc_type_info_tests.cpp" />
+    <ClCompile Include="multiple_translation_units_stub_test.cpp" />
+    <ClCompile Include="multiple_translation_units_stub.cpp" />
     <ClCompile Include="overloadded_methods_tests.cpp" />
     <ClCompile Include="referece_types_tests.cpp" />
     <ClCompile Include="remove_const_volatile_tests.cpp" />
@@ -158,6 +160,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\fakeit\ActualInvocationHandler.hpp" />
+    <ClInclude Include="multiple_translation_units_stub.h" />
     <ClInclude Include="tpunit++.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/tests/multiple_translation_units_stub.cpp
+++ b/tests/multiple_translation_units_stub.cpp
@@ -1,0 +1,12 @@
+#include "multiple_translation_units_stub.h"
+
+
+void stubFunc2(fakeit::Mock<SomeInterface>& mock)
+{
+	fakeit::When(Method(mock, func2)).AlwaysReturn<std::string>("String");
+}
+
+void stubFunc(fakeit::Mock<SomeInterface>& mock)
+{
+	fakeit::When(Method(mock, func)).AlwaysReturn<int>(3);
+}

--- a/tests/multiple_translation_units_stub.h
+++ b/tests/multiple_translation_units_stub.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+#include "fakeit.hpp"
+
+struct SomeInterface {
+	virtual int func() = 0;
+	virtual std::string func2() = 0;
+};
+
+void stubFunc2(fakeit::Mock<SomeInterface>& mock);
+void stubFunc(fakeit::Mock<SomeInterface>& mock);

--- a/tests/multiple_translation_units_stub_test.cpp
+++ b/tests/multiple_translation_units_stub_test.cpp
@@ -1,0 +1,24 @@
+#include "tpunit++.hpp"
+#include "fakeit.hpp"
+#include "multiple_translation_units_stub.h"
+
+using namespace fakeit;
+
+struct MultipleTranslationUnitsStub : tpunit::TestFixture {
+	MultipleTranslationUnitsStub()
+		: tpunit::TestFixture(
+			TEST(MultipleTranslationUnitsStub::NoCollidingIds)
+			)
+	{}
+
+	void NoCollidingIds() {
+		Mock<SomeInterface> mock;
+		SomeInterface &i = mock.get();
+		
+		stubFunc2(mock);
+		When(Method(mock, func)).Return<int>(1);
+
+		mock.get().func2(); // Uncatchable write access violation if ids collide
+	}
+
+} __MultipleTranslationUnitsStub;


### PR DESCRIPTION
We have seen issues where mocked methods defined in different files will end up overwriting each other.  This was because the identifier for the mocked methods was defined by the `__COUNTER__` macro, which increments per compilation unit

This change comes from another fork of FakeIt that looks like it will merge at some point to the main repo