### PR TITLE
Removing copy/move constructors and assignment/copy operator on fakeit::Mock since it doesn't work consistently

### DIFF
--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -31,6 +31,13 @@ namespace fakeit {
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
 
+        // Copying or moving a Mock causes issues where mocked methods don't copy or move with it
+        // Delete both the copy and move constructors, and the assignment and move operators
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
+
         virtual C &get() {
             return impl.get();
         }

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.010273
+ *  Generated: 2023-03-20 07:43:23.626171
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8898,6 +8898,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.078124
+ *  Generated: 2023-03-20 07:43:23.696244
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8936,6 +8936,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/cute/fakeit.hpp
+++ b/single_header/cute/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.141418
+ *  Generated: 2023-03-20 07:43:23.751162
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8863,6 +8863,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/doctest/fakeit.hpp
+++ b/single_header/doctest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.204730
+ *  Generated: 2023-03-20 07:43:23.814100
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8891,6 +8891,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.268034
+ *  Generated: 2023-03-20 07:43:23.876600
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8863,6 +8863,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.331328
+ *  Generated: 2023-03-20 07:43:23.955163
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8885,6 +8885,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.395009
+ *  Generated: 2023-03-20 07:43:24.002454
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8887,6 +8887,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.458304
+ *  Generated: 2023-03-20 07:43:24.064977
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8870,6 +8870,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.521985
+ *  Generated: 2023-03-20 07:43:24.127916
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8871,6 +8871,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.585664
+ *  Generated: 2023-03-20 07:43:24.197437
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8939,6 +8939,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-09 16:30:08.635451
+ *  Generated: 2023-03-20 07:43:24.253355
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -8910,6 +8910,13 @@ namespace fakeit {
 
         explicit Mock(C &obj) : impl(Fakeit, obj) {
         }
+
+
+
+        Mock(const Mock&) = delete;
+        Mock(Mock&&) = delete;
+        Mock& operator=(const Mock&) = delete;
+        Mock& operator=(Mock&&) = delete;
 
         virtual C &get() {
             return impl.get();

--- a/tests/spying_tests.cpp
+++ b/tests/spying_tests.cpp
@@ -209,7 +209,7 @@ struct SpyingTests: tpunit::TestFixture {
 
     void callMemberMethodFromSpiedMethod() {
         Dummy instance;
-        auto spy = Mock<Dummy>(instance);
+        Mock<Dummy> spy(instance);
         Spy(Method(spy, method));
 		Spy(Method(spy, callMethod));
 		spy.get().callMethod();


### PR DESCRIPTION
I was running into issues where after copying a `fakeit::Mock` that some methods would randomly be considered unmocked, but only in unoptimized builds.  Something weird and undefined is happening when `fakeit::Mock` is being copied or moved, so this PR disables those so people don't fall into weird behavior that can happen