### PR TITLE
Fixing an issue where we would read out of bounds if we were spying on an object

### DIFF
--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -121,7 +121,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){

--- a/include/mockutils/gcc/VirtualTable.hpp
+++ b/include/mockutils/gcc/VirtualTable.hpp
@@ -73,7 +73,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
             //firstMethod[-1] = from.firstMethod[-1]; // copy type_info
             for (size_t i = 0; i < size; ++i) {

--- a/include/mockutils/mscpp/VirtualTable.hpp
+++ b/include/mockutils/mscpp/VirtualTable.hpp
@@ -188,12 +188,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+            // Only try to get the cookie if we aren't using a spy. If we aren't using a spy
+            // we end up indexing out of bounds and reading garbage memory
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-20 07:43:23.626171
+ *  Generated: 2023-07-08 18:53:41.524047
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5524,12 +5524,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+
+
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 
@@ -5702,7 +5704,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
 
             for (size_t i = 0; i < size; ++i) {
@@ -5987,13 +5989,14 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &inst) :
+        DynamicProxy(C &inst, bool isUsingSpy) :
                 instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
-                _invocationHandlers(_methodMocks, _offsets) {
-            _cloneVt.copyFrom(originalVtHandle.restore());
+                _invocationHandlers(_methodMocks, _offsets),
+                _isUsingSpy(isUsingSpy) {
+            _cloneVt.copyFrom(originalVtHandle.restore(), isUsingSpy);
             _cloneVt.setCookie(InvocationHandlerCollection::VtCookieIndex, &_invocationHandlers);
             getFake().setVirtualTable(_cloneVt);
         }
@@ -6016,7 +6019,7 @@ namespace fakeit {
             _members = {};
 			_offsets = {};
             _offsets.resize(VTUtils::getVTSize<C>());
-            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.copyFrom(originalVtHandle.restore(), _isUsingSpy);
         }
 
 		void Clear()
@@ -6114,6 +6117,7 @@ namespace fakeit {
         std::vector<std::shared_ptr<Destructible>> _members;
         std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
+        bool _isUsingSpy = false;
 
         FakeObject<C, baseclasses...> &getFake() {
             return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
@@ -8608,7 +8612,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-20 07:43:23.696244
+ *  Generated: 2023-07-08 18:53:41.573198
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5562,12 +5562,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+
+
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 
@@ -5740,7 +5742,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
 
             for (size_t i = 0; i < size; ++i) {
@@ -6025,13 +6027,14 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &inst) :
+        DynamicProxy(C &inst, bool isUsingSpy) :
                 instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
-                _invocationHandlers(_methodMocks, _offsets) {
-            _cloneVt.copyFrom(originalVtHandle.restore());
+                _invocationHandlers(_methodMocks, _offsets),
+                _isUsingSpy(isUsingSpy) {
+            _cloneVt.copyFrom(originalVtHandle.restore(), isUsingSpy);
             _cloneVt.setCookie(InvocationHandlerCollection::VtCookieIndex, &_invocationHandlers);
             getFake().setVirtualTable(_cloneVt);
         }
@@ -6054,7 +6057,7 @@ namespace fakeit {
             _members = {};
 			_offsets = {};
             _offsets.resize(VTUtils::getVTSize<C>());
-            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.copyFrom(originalVtHandle.restore(), _isUsingSpy);
         }
 
 		void Clear()
@@ -6152,6 +6155,7 @@ namespace fakeit {
         std::vector<std::shared_ptr<Destructible>> _members;
         std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
+        bool _isUsingSpy = false;
 
         FakeObject<C, baseclasses...> &getFake() {
             return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
@@ -8646,7 +8650,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){

--- a/single_header/cute/fakeit.hpp
+++ b/single_header/cute/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-20 07:43:23.751162
+ *  Generated: 2023-07-08 18:53:41.621542
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5489,12 +5489,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+
+
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 
@@ -5667,7 +5669,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
 
             for (size_t i = 0; i < size; ++i) {
@@ -5952,13 +5954,14 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &inst) :
+        DynamicProxy(C &inst, bool isUsingSpy) :
                 instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
-                _invocationHandlers(_methodMocks, _offsets) {
-            _cloneVt.copyFrom(originalVtHandle.restore());
+                _invocationHandlers(_methodMocks, _offsets),
+                _isUsingSpy(isUsingSpy) {
+            _cloneVt.copyFrom(originalVtHandle.restore(), isUsingSpy);
             _cloneVt.setCookie(InvocationHandlerCollection::VtCookieIndex, &_invocationHandlers);
             getFake().setVirtualTable(_cloneVt);
         }
@@ -5981,7 +5984,7 @@ namespace fakeit {
             _members = {};
 			_offsets = {};
             _offsets.resize(VTUtils::getVTSize<C>());
-            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.copyFrom(originalVtHandle.restore(), _isUsingSpy);
         }
 
 		void Clear()
@@ -6079,6 +6082,7 @@ namespace fakeit {
         std::vector<std::shared_ptr<Destructible>> _members;
         std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
+        bool _isUsingSpy = false;
 
         FakeObject<C, baseclasses...> &getFake() {
             return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
@@ -8573,7 +8577,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-20 07:43:23.876600
+ *  Generated: 2023-07-08 18:53:41.718989
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5489,12 +5489,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+
+
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 
@@ -5667,7 +5669,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
 
             for (size_t i = 0; i < size; ++i) {
@@ -5952,13 +5954,14 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &inst) :
+        DynamicProxy(C &inst, bool isUsingSpy) :
                 instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
-                _invocationHandlers(_methodMocks, _offsets) {
-            _cloneVt.copyFrom(originalVtHandle.restore());
+                _invocationHandlers(_methodMocks, _offsets),
+                _isUsingSpy(isUsingSpy) {
+            _cloneVt.copyFrom(originalVtHandle.restore(), isUsingSpy);
             _cloneVt.setCookie(InvocationHandlerCollection::VtCookieIndex, &_invocationHandlers);
             getFake().setVirtualTable(_cloneVt);
         }
@@ -5981,7 +5984,7 @@ namespace fakeit {
             _members = {};
 			_offsets = {};
             _offsets.resize(VTUtils::getVTSize<C>());
-            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.copyFrom(originalVtHandle.restore(), _isUsingSpy);
         }
 
 		void Clear()
@@ -6079,6 +6082,7 @@ namespace fakeit {
         std::vector<std::shared_ptr<Destructible>> _members;
         std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
+        bool _isUsingSpy = false;
 
         FakeObject<C, baseclasses...> &getFake() {
             return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
@@ -8573,7 +8577,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-20 07:43:23.955163
+ *  Generated: 2023-07-08 18:53:41.768014
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5511,12 +5511,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+
+
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 
@@ -5689,7 +5691,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
 
             for (size_t i = 0; i < size; ++i) {
@@ -5974,13 +5976,14 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &inst) :
+        DynamicProxy(C &inst, bool isUsingSpy) :
                 instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
-                _invocationHandlers(_methodMocks, _offsets) {
-            _cloneVt.copyFrom(originalVtHandle.restore());
+                _invocationHandlers(_methodMocks, _offsets),
+                _isUsingSpy(isUsingSpy) {
+            _cloneVt.copyFrom(originalVtHandle.restore(), isUsingSpy);
             _cloneVt.setCookie(InvocationHandlerCollection::VtCookieIndex, &_invocationHandlers);
             getFake().setVirtualTable(_cloneVt);
         }
@@ -6003,7 +6006,7 @@ namespace fakeit {
             _members = {};
 			_offsets = {};
             _offsets.resize(VTUtils::getVTSize<C>());
-            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.copyFrom(originalVtHandle.restore(), _isUsingSpy);
         }
 
 		void Clear()
@@ -6101,6 +6104,7 @@ namespace fakeit {
         std::vector<std::shared_ptr<Destructible>> _members;
         std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
+        bool _isUsingSpy = false;
 
         FakeObject<C, baseclasses...> &getFake() {
             return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
@@ -8595,7 +8599,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-20 07:43:24.002454
+ *  Generated: 2023-07-08 18:53:41.817043
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5513,12 +5513,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+
+
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 
@@ -5691,7 +5693,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
 
             for (size_t i = 0; i < size; ++i) {
@@ -5976,13 +5978,14 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &inst) :
+        DynamicProxy(C &inst, bool isUsingSpy) :
                 instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
-                _invocationHandlers(_methodMocks, _offsets) {
-            _cloneVt.copyFrom(originalVtHandle.restore());
+                _invocationHandlers(_methodMocks, _offsets),
+                _isUsingSpy(isUsingSpy) {
+            _cloneVt.copyFrom(originalVtHandle.restore(), isUsingSpy);
             _cloneVt.setCookie(InvocationHandlerCollection::VtCookieIndex, &_invocationHandlers);
             getFake().setVirtualTable(_cloneVt);
         }
@@ -6005,7 +6008,7 @@ namespace fakeit {
             _members = {};
 			_offsets = {};
             _offsets.resize(VTUtils::getVTSize<C>());
-            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.copyFrom(originalVtHandle.restore(), _isUsingSpy);
         }
 
 		void Clear()
@@ -6103,6 +6106,7 @@ namespace fakeit {
         std::vector<std::shared_ptr<Destructible>> _members;
         std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
+        bool _isUsingSpy = false;
 
         FakeObject<C, baseclasses...> &getFake() {
             return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
@@ -8597,7 +8601,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-20 07:43:24.064977
+ *  Generated: 2023-07-08 18:53:41.866779
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5496,12 +5496,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+
+
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 
@@ -5674,7 +5676,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
 
             for (size_t i = 0; i < size; ++i) {
@@ -5959,13 +5961,14 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &inst) :
+        DynamicProxy(C &inst, bool isUsingSpy) :
                 instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
-                _invocationHandlers(_methodMocks, _offsets) {
-            _cloneVt.copyFrom(originalVtHandle.restore());
+                _invocationHandlers(_methodMocks, _offsets),
+                _isUsingSpy(isUsingSpy) {
+            _cloneVt.copyFrom(originalVtHandle.restore(), isUsingSpy);
             _cloneVt.setCookie(InvocationHandlerCollection::VtCookieIndex, &_invocationHandlers);
             getFake().setVirtualTable(_cloneVt);
         }
@@ -5988,7 +5991,7 @@ namespace fakeit {
             _members = {};
 			_offsets = {};
             _offsets.resize(VTUtils::getVTSize<C>());
-            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.copyFrom(originalVtHandle.restore(), _isUsingSpy);
         }
 
 		void Clear()
@@ -6086,6 +6089,7 @@ namespace fakeit {
         std::vector<std::shared_ptr<Destructible>> _members;
         std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
+        bool _isUsingSpy = false;
 
         FakeObject<C, baseclasses...> &getFake() {
             return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
@@ -8580,7 +8584,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-20 07:43:24.127916
+ *  Generated: 2023-07-08 18:53:41.915517
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5497,12 +5497,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+
+
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 
@@ -5675,7 +5677,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
 
             for (size_t i = 0; i < size; ++i) {
@@ -5960,13 +5962,14 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &inst) :
+        DynamicProxy(C &inst, bool isUsingSpy) :
                 instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
-                _invocationHandlers(_methodMocks, _offsets) {
-            _cloneVt.copyFrom(originalVtHandle.restore());
+                _invocationHandlers(_methodMocks, _offsets),
+                _isUsingSpy(isUsingSpy) {
+            _cloneVt.copyFrom(originalVtHandle.restore(), isUsingSpy);
             _cloneVt.setCookie(InvocationHandlerCollection::VtCookieIndex, &_invocationHandlers);
             getFake().setVirtualTable(_cloneVt);
         }
@@ -5989,7 +5992,7 @@ namespace fakeit {
             _members = {};
 			_offsets = {};
             _offsets.resize(VTUtils::getVTSize<C>());
-            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.copyFrom(originalVtHandle.restore(), _isUsingSpy);
         }
 
 		void Clear()
@@ -6087,6 +6090,7 @@ namespace fakeit {
         std::vector<std::shared_ptr<Destructible>> _members;
         std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
+        bool _isUsingSpy = false;
 
         FakeObject<C, baseclasses...> &getFake() {
             return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
@@ -8581,7 +8585,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-03-20 07:43:24.253355
+ *  Generated: 2023-07-08 18:53:42.013668
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5536,12 +5536,14 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool isUsingSpy) {
             auto size = VTUtils::getVTSize<C>();
             for (unsigned int i = 0; i < size; i++) {
                 _firstMethod[i] = from.getMethod(i);
             }
-            if (VTUtils::hasVirtualDestructor<C>())
+
+
+            if (VTUtils::hasVirtualDestructor<C>() && !isUsingSpy)
                 setCookie(dtorCookieIndex, from.getCookie(dtorCookieIndex));
         }
 
@@ -5714,7 +5716,7 @@ namespace fakeit {
             return *vt;
         }
 
-        void copyFrom(VirtualTable<C, baseclasses...> &from) {
+        void copyFrom(VirtualTable<C, baseclasses...> &from, bool) {
             unsigned int size = VTUtils::getVTSize<C>();
 
             for (size_t i = 0; i < size; ++i) {
@@ -5999,13 +6001,14 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &inst) :
+        DynamicProxy(C &inst, bool isUsingSpy) :
                 instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
-                _invocationHandlers(_methodMocks, _offsets) {
-            _cloneVt.copyFrom(originalVtHandle.restore());
+                _invocationHandlers(_methodMocks, _offsets),
+                _isUsingSpy(isUsingSpy) {
+            _cloneVt.copyFrom(originalVtHandle.restore(), isUsingSpy);
             _cloneVt.setCookie(InvocationHandlerCollection::VtCookieIndex, &_invocationHandlers);
             getFake().setVirtualTable(_cloneVt);
         }
@@ -6028,7 +6031,7 @@ namespace fakeit {
             _members = {};
 			_offsets = {};
             _offsets.resize(VTUtils::getVTSize<C>());
-            _cloneVt.copyFrom(originalVtHandle.restore());
+            _cloneVt.copyFrom(originalVtHandle.restore(), _isUsingSpy);
         }
 
 		void Clear()
@@ -6126,6 +6129,7 @@ namespace fakeit {
         std::vector<std::shared_ptr<Destructible>> _members;
         std::vector<size_t> _offsets;
         InvocationHandlers _invocationHandlers;
+        bool _isUsingSpy = false;
 
         FakeObject<C, baseclasses...> &getFake() {
             return reinterpret_cast<FakeObject<C, baseclasses...> &>(instance);
@@ -8620,7 +8624,7 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit, C &obj, bool isSpy)
                 : _instanceOwner(isSpy ? nullptr : asFakeObject(&obj))
-				, _proxy{obj}
+				, _proxy{obj, isSpy}
 				, _fakeit(fakeit) {}
 
         static FakeObject<C, baseclasses...>* asFakeObject(void* instance){


### PR DESCRIPTION
FakeIt has a feature where you can spy on an object, which means you can use FakeIt::Mock on a "real" object instead of a mock one:
https://github.com/eranpeer/FakeIt/wiki/Quickstart#spying

There is a bug where a spied object is treated as a mock object and we will try to read out of bounds where we have addressable memory. That would happen in `VirtualTable::copyFrom`:
https://github.com/Mojang/FakeIt/blob/ed410f70ef92702927170b6eb9f3bef98e21300d/include/mockutils/mscpp/VirtualTable.hpp#L191-L198
https://github.com/Mojang/FakeIt/blob/ed410f70ef92702927170b6eb9f3bef98e21300d/include/mockutils/mscpp/VirtualTable.hpp#L147-L149

Doing this is fine with a mocked object since it allocates memory to read and write there, but not a spied one.

This fix makes `DynamicProxy` aware if the object is a spy or not, and passes that context down to `VirtualTable` to know if it needs to copy the cookie.

This is only a problem with the MSVC version of this code, the other implementation of `VirtualTable` doesn't have this code.

Everything under the "single_header" directory is generated code