### PR TITLE
Bug 1499288: [100% Repro] [Bedrock_Windows_CI] [win32_x86 --unity --p…ch] Tests "Minecraft.UnitTest.Runner" and "Vanilla.SharedTests.UnitTest.Runner" are failing in run tests step

### DIFF
--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -419,7 +419,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/include/mockutils/mscpp/VirtualTable.hpp
+++ b/include/mockutils/mscpp/VirtualTable.hpp
@@ -220,8 +220,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.524047
+ *  Generated: 2025-10-15 20:40:54.910611
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5556,8 +5556,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7851,7 +7851,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.573198
+ *  Generated: 2025-10-15 20:40:54.946323
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5594,8 +5594,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7889,7 +7889,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/single_header/cute/fakeit.hpp
+++ b/single_header/cute/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.621542
+ *  Generated: 2025-10-15 20:40:54.994182
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5521,8 +5521,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7816,7 +7816,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/single_header/doctest/fakeit.hpp
+++ b/single_header/doctest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.670237
+ *  Generated: 2025-10-15 20:40:55.041783
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5549,8 +5549,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7844,7 +7844,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.718989
+ *  Generated: 2025-10-15 20:40:55.079306
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5521,8 +5521,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7816,7 +7816,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.768014
+ *  Generated: 2025-10-15 20:40:55.121053
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5543,8 +5543,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7838,7 +7838,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.817043
+ *  Generated: 2025-10-15 20:40:55.169261
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5545,8 +5545,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7840,7 +7840,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/single_header/nunit/fakeit.hpp
+++ b/single_header/nunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.866779
+ *  Generated: 2025-10-15 20:40:55.200480
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5528,8 +5528,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7823,7 +7823,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.915517
+ *  Generated: 2025-10-15 20:40:55.248030
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5529,8 +5529,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7824,7 +7824,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:41.964544
+ *  Generated: 2025-10-15 20:40:55.295920
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5597,8 +5597,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2023-07-08 18:53:42.013668
+ *  Generated: 2025-10-15 20:40:55.329457
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -5568,8 +5568,8 @@ namespace fakeit {
             C &cRef = *c;
             auto vt = VirtualTable<C, baseclasses...>::getVTable(cRef);
             void *dtorPtr = vt.getCookie(dtorCookieIndex);
-            void(*method)(C *) = reinterpret_cast<void (*)(C *)>(dtorPtr);
-            method(c);
+            void(C::*method)() = union_cast<void(C::*)()>(dtorPtr);
+            (cRef.*method)();
             return 0;
         }
 
@@ -7863,7 +7863,7 @@ namespace fakeit {
             template<typename current_arg, typename ... valuelist, typename ... arglist>
             static void
             Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
-                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                ParamWalker<N - 1>::Assign(arg_vals, std::forward<arglist>(args)...);
                 GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
             }
         };


### PR DESCRIPTION
Fix crash in mocked destructors in x86. Destructor mocks use union_cast to cast a member pointer to a void*. When the mock is to be called, those are pulled back out and cast to a non-member function that takes the class. Due to luck and calling convention, this happens to work, but stopped now on x86. Fix the issue by union_casting the object back to the member function it original was rather than a different non-member function. Additionally, apply the previous xcode fix to the headers so running the generation script doesn't erase it: https://github.com/Mojang/FakeIt/commit/6b685cb896ef8e4879de5be22cf535dc1846543a

This is a simplified version of the type of casting it was doing, which works on x64 but crashes now on x86.
```c++
		TestS s;
		void (TestS::*mfc)() = &TestS::fn2;
		void* vmfc = fakeit::union_cast<void*>(mfc);
		reinterpret_cast<void(*)(TestS*)>(vmfc)(&s);
```