### PR TITLE
User Story AB#1502254: Update images to use current LTS versions to allow builds to start

### DIFF
--- a/.github/workflows/ci_linux_clang.yml
+++ b/.github/workflows/ci_linux_clang.yml
@@ -9,20 +9,8 @@ defaults:
     shell: bash
 
 jobs:
-  clang-ubuntu-20-04:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build project
-        run: |
-          cd build
-          make -f clang_makefile all
-      - name: Run tests
-        run: |
-          cd build
-          ./fakeit_tests.exe
-  clang-ubuntu-18-04:
-    runs-on: ubuntu-18.04
+  clang-ubuntu-22-04:
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Build project

--- a/.github/workflows/ci_linux_gcc.yml
+++ b/.github/workflows/ci_linux_gcc.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install LCOV
         run: sudo apt install -y lcov
@@ -35,19 +35,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./build/report_filtered.info
   gcc-ubuntu-20-04:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build project
-        run: |
-          cd build
-          make all
-      - name: Run tests
-        run: |
-          cd build
-          ./fakeit_tests.exe
-  gcc-ubuntu-18-04:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Build project

--- a/.github/workflows/ci_linux_gcc.yml
+++ b/.github/workflows/ci_linux_gcc.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./build/report_filtered.info
-  gcc-ubuntu-20-04:
+  gcc-ubuntu-22-04:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 16.04, 18.04, and 20.04 have been deprecated and removed from the build files so the checks will start running.
